### PR TITLE
Version 1.1.3

### DIFF
--- a/src/main/java/de/carldressler/autovoice/Bot.java
+++ b/src/main/java/de/carldressler/autovoice/Bot.java
@@ -30,7 +30,7 @@ public class Bot {
         String token = getToken();
         jda = JDABuilder
             .createDefault(token)
-            .setActivity(Activity.watching(Constants.PREFIX + "help \uD83C\uDF89 v 1.1.2"))
+            .setActivity(Activity.watching(Constants.PREFIX + "help \uD83C\uDF89 v 1.1.3"))
             .addEventListeners(new CommandHandler(),
                 new VoiceEventListener(),
                 new ChannelEventListener())

--- a/src/main/java/de/carldressler/autovoice/commands/tempchannel/LimitCommand.java
+++ b/src/main/java/de/carldressler/autovoice/commands/tempchannel/LimitCommand.java
@@ -22,13 +22,21 @@ public class LimitCommand extends Command {
     public void run(CommandContext ctxt) {
         int userLimit;
 
-        if (ctxt.args.isEmpty())
+        if (ctxt.args.isEmpty()) {
+
             userLimit = ctxt.voiceChannel.getMembers().size();
-        else if (ctxt.args.get(0).matches("^(0?[1-9]|[1-9][0-9])$"))
+            if (ctxt.voiceChannel.getUserLimit() != 0)
+                userLimit = 0;
+
+        } else if (ctxt.args.get(0).matches("^(0?[0-9]|[1-9][0-9])$")) {
+
             userLimit = Integer.parseInt(ctxt.args.get(0));
-        else {
+
+        } else {
+
             ctxt.textChannel.sendMessage(getInvalidNumber()).queue();
             return;
+
         }
 
         if (userLimit > 99)


### PR DESCRIPTION
### Changes

- it is now possible to remove a channel user limit using the `limit` command
  - by not setting an argument
  - by passing "0" as the argument 